### PR TITLE
[swift/main] Migrate to internal imports

### DIFF
--- a/Sources/RegexBenchmark/Benchmark.swift
+++ b/Sources/RegexBenchmark/Benchmark.swift
@@ -1,5 +1,5 @@
 @_spi(RegexBenchmark) import _StringProcessing
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 import Foundation
 
 protocol RegexBenchmark: Debug {

--- a/Sources/RegexBuilder/Anchor.swift
+++ b/Sources/RegexBuilder/Anchor.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 @_spi(RegexBuilder) import _StringProcessing
 
 /// A regex component that matches a specific condition at a particular position

--- a/Sources/RegexBuilder/CharacterClass.swift
+++ b/Sources/RegexBuilder/CharacterClass.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 @_spi(RegexBuilder) import _StringProcessing
 
 /// A class of characters that match in a regex.

--- a/Sources/RegexBuilder/DSL.swift
+++ b/Sources/RegexBuilder/DSL.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 @_spi(RegexBuilder) import _StringProcessing
 
 @available(SwiftStdlib 5.7, *)

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -12,7 +12,7 @@
 @_spi(_Unicode)
 import Swift
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 extension Compiler {
   struct ByteCodeGen {

--- a/Sources/_StringProcessing/Capture.swift
+++ b/Sources/_StringProcessing/Capture.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 // TODO: Where should this live? Inside TypeConstruction?
 func constructExistentialOutputComponent(

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 class Compiler {
   let tree: DSLTree

--- a/Sources/_StringProcessing/ConsumerInterface.swift
+++ b/Sources/_StringProcessing/ConsumerInterface.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 extension Character {
   var _singleScalarAsciiValue: UInt8? {

--- a/Sources/_StringProcessing/Engine/InstPayload.swift
+++ b/Sources/_StringProcessing/Engine/InstPayload.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 extension Instruction {
   /// An instruction's payload packs operands and destination

--- a/Sources/_StringProcessing/Engine/MEBuilder.swift
+++ b/Sources/_StringProcessing/Engine/MEBuilder.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser // For errors
+internal import _RegexParser // For errors
 
 extension MEProgram {
   struct Builder {

--- a/Sources/_StringProcessing/Engine/MEBuiltins.swift
+++ b/Sources/_StringProcessing/Engine/MEBuiltins.swift
@@ -1,4 +1,4 @@
-@_implementationOnly import _RegexParser // For AssertionKind
+internal import _RegexParser // For AssertionKind
 extension Character {
   var _isHorizontalWhitespace: Bool {
     self.unicodeScalars.first?.isHorizontalWhitespace == true

--- a/Sources/_StringProcessing/Engine/MECapture.swift
+++ b/Sources/_StringProcessing/Engine/MECapture.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 /*
 

--- a/Sources/_StringProcessing/Engine/MEProgram.swift
+++ b/Sources/_StringProcessing/Engine/MEProgram.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 struct MEProgram {
   typealias Input = String

--- a/Sources/_StringProcessing/Engine/Registers.swift
+++ b/Sources/_StringProcessing/Engine/Registers.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 struct SentinelValue: Hashable, CustomStringConvertible {
   var description: String { "<value sentinel>" }

--- a/Sources/_StringProcessing/Engine/Structuralize.swift
+++ b/Sources/_StringProcessing/Engine/Structuralize.swift
@@ -1,4 +1,4 @@
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 extension CaptureList {
   @available(SwiftStdlib 5.7, *)

--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 struct Executor {
   // TODO: consider let, for now lets us toggle tracing

--- a/Sources/_StringProcessing/LiteralPrinter.swift
+++ b/Sources/_StringProcessing/LiteralPrinter.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 @available(SwiftStdlib 5.7, *)
 extension Regex {

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 /// A type that represents the current state of regex matching options, with
 /// stack-based scoping.

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 // TODO: Add an expansion level, both from top to bottom.
 //       After `printAsCanonical` is fleshed out, these two

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 extension AST {
   var dslTree: DSLTree {

--- a/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
+++ b/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 /// The type-erased, dynamic output of a regular expression match.
 ///

--- a/Sources/_StringProcessing/Regex/Core.swift
+++ b/Sources/_StringProcessing/Regex/Core.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 /// A type that represents a regular expression.
 ///

--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 @_spi(RegexBuilder)
 public struct DSLTree {

--- a/Sources/_StringProcessing/Regex/Options.swift
+++ b/Sources/_StringProcessing/Regex/Options.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 @available(SwiftStdlib 5.7, *)
 extension Regex {

--- a/Sources/_StringProcessing/Utility/ASTBuilder.swift
+++ b/Sources/_StringProcessing/Utility/ASTBuilder.swift
@@ -25,7 +25,7 @@ AST.
 
 */
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 func alt(_ asts: [AST.Node]) -> AST.Node {
   return .alternation(

--- a/Sources/_StringProcessing/Utility/TypeVerification.swift
+++ b/Sources/_StringProcessing/Utility/TypeVerification.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 @available(SwiftStdlib 5.7, *)
 extension Regex {

--- a/Sources/_StringProcessing/_CharacterClassModel.swift
+++ b/Sources/_StringProcessing/_CharacterClassModel.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _RegexParser
+internal import _RegexParser
 
 // NOTE: This is a model type. We want to be able to get one from
 // an AST, but this isn't a natural thing to produce in the context


### PR DESCRIPTION
Cherry pick of https://github.com/swiftlang/swift-experimental-string-processing/pull/755.

As of the Swift 6 compiler, `@_implementationOnly import` is deprecated in favor of `internal import` and as a result the use of `@_implementationOnly import` in this project is generating a lot of diagnostic noise when building the Swift standard library.

For Swift libraries with library evolution, `@_implementationOnly import` and `internal import` are roughly functionally equivalent, aside from improved diagnostics for `internal import`. For non-resilient libraries, the main difference is that `internal import` does not actually hide a module dependency from downstream clients because the layout of a type in a non-resilient library may depend on types coming from an `internal import` (with `@_implementationOnly import` the same situation would result in a silent mis-compile, which is the reason that `@_implementationOnly import` is deprecated). The `_RegexParser` module dependency does not need to be hidden from clients since it is installed in standard locations in the SDK/toolchain. Therefore this migration should be safe, regardless of library resilience mode.