### PR TITLE
Use Bionic module from new Android overlay in Swift 6 instead

### DIFF
--- a/Sources/VariadicsGenerator/VariadicsGenerator.swift
+++ b/Sources/VariadicsGenerator/VariadicsGenerator.swift
@@ -18,6 +18,8 @@ import Darwin
 import Glibc
 #elseif os(Windows)
 import CRT
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 // (T), (T)


### PR DESCRIPTION
The new module and overlay were merged into Swift 6 in swiftlang/swift#74758.