### PR TITLE
Limit recursion in regex parser (#757)

### DIFF
--- a/Tests/RegexTests/ParseTests.swift
+++ b/Tests/RegexTests/ParseTests.swift
@@ -3335,6 +3335,13 @@ extension RegexTests {
       + "a"
       + String(repeating: ")*", count: 500),
       .nestingTooDeep)
+
+    diagnosticTest(
+      String(repeating: "[", count: 500)
+      + "a"
+      + String(repeating: "]*", count: 500),
+      .nestingTooDeep)
+
   }
 
   func testDelimiterLexingErrors() {


### PR DESCRIPTION
Cherry-picks some more changes from swift/main.

* Limit recursion in regex parser

* Also check for custom char class nesting