### PR TITLE
Add missing imports of `_RegexParser`

### DIFF
--- a/Sources/_StringProcessing/Engine/MEQuantify.swift
+++ b/Sources/_StringProcessing/Engine/MEQuantify.swift
@@ -1,3 +1,5 @@
+internal import _RegexParser
+
 private typealias ASCIIBitset = DSLTree.CustomCharacterClass.AsciiBitset
 
 extension Processor {

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+internal import _RegexParser
 
 enum MatchMode {
   case wholeString

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+internal import _RegexParser
+
 @available(SwiftStdlib 5.7, *)
 extension Regex {
   /// The result of matching a regular expression against a string.

--- a/Sources/_StringProcessing/Unicode/NFC.swift
+++ b/Sources/_StringProcessing/Unicode/NFC.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+internal import _RegexParser
+
 @_spi(_Unicode)
 import Swift
 

--- a/Sources/_StringProcessing/Unicode/ScalarProps.swift
+++ b/Sources/_StringProcessing/Unicode/ScalarProps.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+internal import _RegexParser
+
 @_silgen_name("_swift_string_processing_getScript")
 func _swift_string_processing_getScript(_: UInt32) -> UInt8
 

--- a/Sources/_StringProcessing/Unicode/WordBreaking.swift
+++ b/Sources/_StringProcessing/Unicode/WordBreaking.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+internal import _RegexParser
+
 @_spi(_Unicode)
 import Swift
 

--- a/Sources/_StringProcessing/Utility/TypedInt.swift
+++ b/Sources/_StringProcessing/Utility/TypedInt.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+internal import _RegexParser
 
 // Just a phantom-typed Int wrapper.
 struct TypedInt<👻>: RawRepresentable, Hashable {


### PR DESCRIPTION
While experimenting with adopting the `MemberImportVisibility` experimental feature (SE-0444) in the standard library build, I found that the `_StringProcessing` module was relying on transitive imports of `_RegexParser` in many source files.