### PR TITLE
Customize `NSError.localizedDescription` for Regex

### DIFF
--- a/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
+++ b/Sources/_RegexParser/Regex/Parse/Diagnostics.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -363,6 +363,14 @@ public struct Diagnostics: Hashable {
       struct ErrorDiagnostic: Error, CustomStringConvertible {
         var diag: Diagnostic
         var description: String { diag.message }
+#if _runtime(_ObjC) && !$Embedded
+        // Error protocol requirements for NSError bridging.
+        var _domain: String { "_RegexParser.Diagnostics" }
+        var _code: Int { 0 }
+        var _userInfo: AnyObject? {
+          [/*kCFErrorDescriptionKey*/ "NSDescription": description] as AnyObject
+        }
+#endif
       }
       throw Source.LocatedError(ErrorDiagnostic(diag: diag), diag.location)
     }

--- a/Sources/_RegexParser/Regex/Parse/SourceLocation.swift
+++ b/Sources/_RegexParser/Regex/Parse/SourceLocation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -126,6 +126,15 @@ extension Source.LocatedError: CustomStringConvertible {
     return error
   }
 }
+
+#if _runtime(_ObjC) && !$Embedded
+extension Source.LocatedError {
+  // Error protocol requirements for NSError bridging.
+  public var _domain: String { error._domain }
+  public var _code: Int { error._code }
+  public var _userInfo: AnyObject? { error._userInfo }
+}
+#endif
 
 extension Error {
   func addingLocation(_ loc: Range<Source.Position>) -> Error {

--- a/Tests/RegexTests/DiagnosticTests.swift
+++ b/Tests/RegexTests/DiagnosticTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2021-2022 Apple Inc. and the Swift project authors
+// Copyright (c) 2021-2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -105,6 +105,19 @@ extension RegexTests {
       print("\(ParseError.emptyProperty)")
       print("\(ParseError.expectedNumber("abc", kind: .decimal))")
       print("\(ParseError.expectedNumber("abc", kind: .hex))")
+    }
+  }
+
+  func testErrorDescriptions() {
+    XCTAssertThrowsError(try Regex(#"\"#)) { error in
+      let message = "\(error)"
+      XCTAssertEqual(message, "expected escape sequence")
+#if _runtime(_ObjC) && !$Embedded
+      // Last resort from _CFErrorCreateLocalizedDescription:
+      // "The operation couldn’t be completed. (DOMAIN error CODE - MESSAGE)"
+      XCTAssertTrue(error.localizedDescription.contains(message))
+      XCTAssertEqual((error as NSError).domain, "_RegexParser.Diagnostics")
+#endif
     }
   }
 }


### PR DESCRIPTION
Regex initializers currently throw `any Error` if the given pattern is invalid.

```swift
import Foundation

do {
  let regex = try Regex(#"\"#)
} catch {
  print(error)
  print(error.localizedDescription)
}
```

* The diagnostic message is useful:

  > expected escape sequence

  but can it be relied upon? This pull request adds a test.

* The localized description contains a 138-character error domain, and a meaningless error code:

  > The operation couldn’t be completed. (_RegexParser.Source.LocatedError<_RegexParser.Diagnostics.(unknown context at $26f700fac).(unknown context at $26f700fb4).ErrorDiagnostic> error 1.)

  This pull request customizes the error domain, and appends the diagnostic message:

  > The operation couldn’t be completed. (_RegexParser.Diagnostics error 0 - expected escape sequence)

  The error code is still meaningless, but so are those derived from ParseError — because the compiler seems to reorganize enum cases by payload.

---

Alternatives:

1.  Typed throws?

2.  Use the same error domain and code as [NSRegularExpression](https://github.com/swiftlang/swift-corelibs-foundation/blob/swift-6.0.1-RELEASE/Sources/CoreFoundation/CFRegularExpression.c#L145) but without the NSInvalidValue key?