### PR TITLE
[NFC] Re-enable tests for capture type munging

### DIFF
--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1831,7 +1831,6 @@ fileprivate let regexWithNonCapture = #/:(?:\d+):/#
 @available(SwiftStdlib 5.7, *)
 extension RegexDSLTests {
   func testLabeledCaptures_regularCapture() throws {
-    return
     // The output type of a regex with unlabeled captures is concatenated.
     let dslWithCapture = Regex {
       OneOrMore(.word)
@@ -1846,7 +1845,6 @@ extension RegexDSLTests {
   }
   
   func testLabeledCaptures_labeledCapture() throws {
-    return
     guard #available(macOS 13, *) else {
       throw XCTSkip("Fix only exists on macOS 13")
     }
@@ -1870,7 +1868,6 @@ extension RegexDSLTests {
   }
   
   func testLabeledCaptures_coalescingWithCapture() throws {
-    return
     let coalescingWithCapture = Regex {
       "e" as Character
       #/\u{301}(\d*)/#
@@ -1887,7 +1884,6 @@ extension RegexDSLTests {
   }
   
   func testLabeledCaptures_bothCapture() throws {
-    return
     guard #available(macOS 13, *) else {
       throw XCTSkip("Fix only exists on macOS 13")
     }


### PR DESCRIPTION
The RegexBuilder tests for working with composed regexes with capture tuple types that don't play well with DSL methods were inadvertently disabled in a previous commit (by me). This re-enables those tests.