### PR TITLE
Make generic wrappers inlinable for specialization

### DIFF
--- a/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
+++ b/Sources/_StringProcessing/Algorithms/Matching/FirstMatch.swift
@@ -19,6 +19,7 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// - Returns: The first match of `regex` in the collection, or `nil` if
   /// there isn't a match.
   @available(SwiftStdlib 5.7, *)
+  @inlinable
   public func firstMatch<Output>(
     of r: some RegexComponent<Output>
   ) -> Regex<Output>.Match? {

--- a/Sources/_StringProcessing/Regex/Match.swift
+++ b/Sources/_StringProcessing/Regex/Match.swift
@@ -303,6 +303,7 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// - Parameter regex: The regular expression to match.
   /// - Returns: The match, if one is found. If there is no match, or a
   ///   transformation in `regex` throws an error, this method returns `nil`.
+  @inlinable
   public func wholeMatch<R: RegexComponent>(
     of regex: R
   ) -> Regex<R.RegexOutput>.Match? {
@@ -314,6 +315,7 @@ extension BidirectionalCollection where SubSequence == Substring {
   /// - Parameter regex: The regular expression to match.
   /// - Returns: The match, if one is found. If there is no match, or a
   ///   transformation in `regex` throws an error, this method returns `nil`.
+  @inlinable
   public func prefixMatch<R: RegexComponent>(
     of regex: R
   ) -> Regex<R.RegexOutput>.Match? {


### PR DESCRIPTION
Benchmarks are behaving a little bit inconsistently for me, but overall improvement:

```
=== Regressions ======================================================================
- EmojiRegex_All                          126ms	123ms	2.25ms		1.8%
- EmailBuiltinCharacterClass_All          8.53ms	8.29ms	232µs		2.8%
- EmailBuiltinCharacterClass_All_Scalar   8.31ms	8.1ms	214µs		2.6%
- ReluctantQuant_Whole                    3.41ms	3.24ms	162µs		5.0%
- HangulSyllable_All_Scalar               2.62ms	2.47ms	152µs		6.1%
- InvertedCCC_All_Scalar                  5.39ms	5.25ms	143µs		2.7%
- BasicCCC_All                            3.24ms	3.15ms	89.5µs		2.8%
- Words_All_Scalar                        4.05ms	4ms	54.2µs		1.4%
- LiteralSearch_All_Scalar                2.31ms	2.27ms	39.6µs		1.7%
- IntersectionCCC_All                     5.47ms	5.43ms	39.5µs		0.7%
- IntersectionCCC_All_Scalar              5.46ms	5.43ms	37.4µs		0.7%
- SubtractionCCC_All_Scalar               5.86ms	5.83ms	37.4µs		0.6%
- Numbers_All                             2.71ms	2.69ms	27.5µs		1.0%
- BasicCCC_All_Scalar                     3.16ms	3.14ms	20.3µs		0.6%
- SubtractionCCC_All                      5.84ms	5.83ms	18.7µs		0.3%
=== Improvements =====================================================================
- CompilerMessages_All                    88.1ms	92.2ms	-4.02ms		-4.4%
- CompilerMessages_All_Scalar             71.6ms	73.8ms	-2.12ms		-2.9%
- EmojiRegex_All_Scalar                   42.5ms	43.6ms	-1.14ms		-2.6%
- symDiffCCC_All                          17.3ms	18.4ms	-1.05ms		-5.7%
- symDiffCCC_All_Scalar                   17.3ms	18.3ms	-955µs		-5.2%
- EmailRFCNoMatches_All_Scalar            42.4ms	43ms	-646µs		-1.5%
- EmailRFC_All_Scalar                     29.9ms	30.5ms	-600µs		-2.0%
- EmailRFC_All                            31ms	31.6ms	-519µs		-1.6%
- EmailRFCNoMatches_All                   46.5ms	47ms	-511µs		-1.1%
- DiceRollsInText_All                     27.9ms	28.4ms	-474µs		-1.7%
- EmailLookahead_All                      18.8ms	19.3ms	-465µs		-2.4%
- DiceRollsInText_All_Scalar              25.8ms	26.2ms	-415µs		-1.6%
- EmailLookahead_All_Scalar               16.8ms	17.1ms	-323µs		-1.9%
- DiceNotation                            4.03ms	4.35ms	-318µs		-7.3%
- AnchoredNotFound_First                  8.8ms	9.04ms	-236µs		-2.6%
- AnchoredNotFound_All                    8.8ms	9.03ms	-227µs		-2.5%
- EmailLookaheadList                      3.85ms	4.06ms	-215µs		-5.3%
- EmailLookaheadList_Scalar               3.68ms	3.89ms	-212µs		-5.4%
- DiceNotation_Scalar                     3.94ms	4.15ms	-209µs		-5.0%
- Numbers_All_Scalar                      1.99ms	2.19ms	-198µs		-9.0%
- IPv4Address_Scalar                      1.81ms	1.98ms	-177µs		-8.9%
- IPv4Address                             1.95ms	2.12ms	-166µs		-7.8%
- IPv6Address                             2.24ms	2.4ms	-163µs		-6.8%
- IPv6Address_Scalar                      2.1ms	2.26ms	-158µs		-7.0%
- MACAddress_Scalar                       2.16ms	2.31ms	-143µs		-6.2%
- NotFound_All                            3.95ms	4.08ms	-130µs		-3.2%
- ReluctantQuant_Whole_Scalar             3.31ms	3.44ms	-130µs		-3.8%
- MACAddress                              2.29ms	2.41ms	-124µs		-5.1%
- AnchoredNotFound_All_Scalar             5.55ms	5.68ms	-124µs		-2.2%
- AnchoredNotFound_First_Scalar           5.55ms	5.67ms	-120µs		-2.1%
- NotFound_All_Scalar                     2.56ms	2.67ms	-114µs		-4.3%
- EmailLookaheadNoMatches_All_Scalar      18.4ms	18.5ms	-85.6µs		-0.5%
- ReluctantQuantWithTerminal_Whole_Scalar 5.63ms	5.71ms	-75.5µs		-1.3%
- GraphemeBreakNoCap_All                  1.61ms	1.68ms	-70.8µs		-4.2%
- Lines_All                               845µs	872µs	-26.9µs		-3.1%
- URLWithWordBoundaries_All               3.45ms	3.47ms	-17.5µs		-0.5%
- URLWithWordBoundaries_All_Scalar        3.28ms	3.3ms	-16.9µs		-0.5%
- URLWithWordBoundaries_All_SimpleWordBoundaries 607µs	621µs	-13.6µs		-2.2%
```