### PR TITLE
Add UTF8 byte matching optimization

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -96,7 +96,7 @@ let package = Package(
                 swiftSettings: [availabilityDefinition]),
         .testTarget(
             name: "RegexTests",
-            dependencies: ["_StringProcessing", "TestSupport"],
+            dependencies: ["_StringProcessing", "RegexBuilder", "TestSupport"],
             swiftSettings: [
                 availabilityDefinition
             ]),

--- a/Sources/RegexBenchmark/BenchmarkRegistration.swift
+++ b/Sources/RegexBenchmark/BenchmarkRegistration.swift
@@ -20,6 +20,7 @@ extension BenchmarkRunner {
     self.addIpAddress()
 
     self.addURLWithWordBoundaries()
+    self.addFSPathsRegex()
     // -- end of registrations --
   }
 }

--- a/Sources/RegexBenchmark/Inputs/FSPaths.swift
+++ b/Sources/RegexBenchmark/Inputs/FSPaths.swift
@@ -1,0 +1,51 @@
+// Successful match FSPaths
+private let fsPathSuccess = #"""
+./First/Second/Third/some/really/long/content.extension/more/stuff/OptionLeft
+./First/Second/Third/some/really/long/content.extension/more/stuff/OptionRight
+./First/Second/PrefixThird/some/really/long/content.extension/more/stuff/OptionLeft
+./First/Second/PrefixThird/some/really/long/content.extension/more/stuff/OptionRight
+"""#
+
+// Unsucessful match FSPaths.
+//
+// We will have far more failures than successful matches by interspersing
+// this whole list between each success
+private let fsPathFailure = #"""
+a/b/c
+/smol/path
+/a/really/long/path/that/is/certainly/stored/out/of/line
+./First/Second/Third/some/really/long/content.extension/more/stuff/NothingToSeeHere
+./First/Second/PrefixThird/some/really/long/content.extension/more/stuff/NothingToSeeHere
+./First/Second/Third/some/really/long/content.extension/more/stuff/OptionNeither
+./First/Second/PrefixThird/some/really/long/content.extension/more/stuff/OptionNeither
+/First/Second/Third/some/really/long/content.extension/more/stuff/OptionLeft
+/First/Second/Third/some/really/long/content.extension/more/stuff/OptionRight
+/First/Second/PrefixThird/some/really/long/content.extension/more/stuff/OptionLeft
+/First/Second/PrefixThird/some/really/long/content.extension/more/stuff/OptionRight
+./First/Second/Third/some/really/long/content/more/stuff/OptionLeft
+./First/Second/Third/some/really/long/content/more/stuff/OptionRight
+./First/Second/PrefixThird/some/really/long/content/more/stuff/OptionLeft
+./First/Second/PrefixThird/some/really/long/content/more/stuff/OptionRight
+"""#
+
+extension Inputs {
+  static let fsPathsList: [String] = {
+    var result: [String] = []
+    let failures: [String] = fsPathFailure.split(whereSeparator: { $0.isNewline }).map { String($0) }
+    result.append(contentsOf: failures)
+
+    for success in fsPathSuccess.split(whereSeparator: { $0.isNewline }) {
+      result.append(String(success))
+      result.append(contentsOf: failures)
+    }
+
+    // Scale result up a bit
+    result.append(contentsOf: result)
+    result.append(contentsOf: result)
+    result.append(contentsOf: result)
+    result.append(contentsOf: result)
+
+    return result
+
+  }()
+}

--- a/Sources/RegexBenchmark/Suite/FSPathsRegex.swift
+++ b/Sources/RegexBenchmark/Suite/FSPathsRegex.swift
@@ -1,0 +1,16 @@
+import _StringProcessing
+
+
+extension BenchmarkRunner {
+  mutating func addFSPathsRegex() {
+    let fsPathsRegex =
+    #"^\./First/Second/(Prefix)?Third/.*\.extension/.*(OptionLeft|OptionRight)$"#
+    let paths = CrossInputListBenchmark(
+      baseName: "FSPathsRegex",
+      regex: fsPathsRegex,
+      inputs: Inputs.fsPathsList
+    )
+    paths.register(&self)
+  }
+}
+

--- a/Sources/RegexBenchmark/Suite/URLRegex.swift
+++ b/Sources/RegexBenchmark/Suite/URLRegex.swift
@@ -12,3 +12,4 @@ extension BenchmarkRunner {
     url.register(&self)
   }
 }
+

--- a/Sources/_StringProcessing/Engine/InstPayload.swift
+++ b/Sources/_StringProcessing/Engine/InstPayload.swift
@@ -43,7 +43,7 @@ extension Instruction.Payload {
     // and variables
 
     case string(StringRegister)
-    case sequence(SequenceRegister)
+    case utf8(UTF8Register)
     case position(PositionRegister)
     case optionalString(StringRegister?)
     case int(IntRegister)
@@ -168,10 +168,18 @@ extension Instruction.Payload {
     return (scalar, caseInsensitive: caseInsensitive, boundaryCheck: boundaryCheck)
   }
 
-  init(sequence: SequenceRegister) {
-    self.init(sequence)
+  init(utf8: UTF8Register, boundaryCheck: Bool) {
+    self.init(boundaryCheck ? 1 : 0, utf8)
   }
-  var sequence: SequenceRegister {
+  var matchUTF8Payload: (UTF8Register, boundaryCheck: Bool) {
+    let pair: (UInt64, UTF8Register) = interpretPair()
+    return (pair.1, pair.0 == 1)
+  }
+
+  init(utf8: UTF8Register) {
+    self.init(utf8)
+  }
+  var utf8: UTF8Register {
     interpret()
   }
 

--- a/Sources/_StringProcessing/Engine/Instruction.swift
+++ b/Sources/_StringProcessing/Engine/Instruction.swift
@@ -112,6 +112,17 @@ extension Instruction {
     /// Operands: Scalar value to match against and booleans
     case matchScalar
 
+    /// Match directly (binary semantics) against a series of UTF-8 bytes
+    ///
+    /// NOTE: Compiler should ensure to only emit this instruction when normalization
+    /// is not required. E.g., scalar-semantic mode or when the matched portion is entirely ASCII
+    /// (which is invariant under NFC). Similary, this is case-sensitive.
+    ///
+    /// TODO: should we add case-insensitive?
+    ///
+    ///     matchUTF8(_: UTF8Register, boundaryCheck: Bool)
+    case matchUTF8
+
     /// Match a character or a scalar against a set of valid ascii values stored in a bitset
     ///
     ///     matchBitset(_: AsciiBitsetRegister, isScalar: Bool)

--- a/Sources/_StringProcessing/Engine/MEBuilder.swift
+++ b/Sources/_StringProcessing/Engine/MEBuilder.swift
@@ -20,7 +20,7 @@ extension MEProgram {
     var enableMetrics = false
 
     var elements = TypedSetVector<Input.Element, _ElementRegister>()
-    var sequences = TypedSetVector<[Input.Element], _SequenceRegister>()
+    var utf8Contents = TypedSetVector<[UInt8], _UTF8Register>()
 
     var asciiBitsets: [DSLTree.CustomCharacterClass.AsciiBitset] = []
     var consumeFunctions: [ConsumeFunction] = []
@@ -196,6 +196,11 @@ extension MEProgram.Builder {
   mutating func buildMatch(_ e: Character, isCaseInsensitive: Bool) {
     instructions.append(.init(
       .match, .init(element: elements.store(e), isCaseInsensitive: isCaseInsensitive)))
+  }
+
+  mutating func buildMatchUTF8(_ utf8: Array<UInt8>, boundaryCheck: Bool) {
+    instructions.append(.init(.matchUTF8, .init(
+      utf8: utf8Contents.store(utf8), boundaryCheck: boundaryCheck)))
   }
 
   mutating func buildMatchScalar(_ s: Unicode.Scalar, boundaryCheck: Bool) {
@@ -416,7 +421,7 @@ extension MEProgram.Builder {
 
     var regInfo = MEProgram.RegisterInfo()
     regInfo.elements = elements.count
-    regInfo.sequences = sequences.count
+    regInfo.utf8Contents = utf8Contents.count
     regInfo.ints = nextIntRegister.rawValue
     regInfo.values = nextValueRegister.rawValue
     regInfo.positions = nextPositionRegister.rawValue
@@ -430,7 +435,7 @@ extension MEProgram.Builder {
     return MEProgram(
       instructions: InstructionList(instructions),
       staticElements: elements.stored,
-      staticSequences: sequences.stored,
+      staticUTF8Contents: utf8Contents.stored,
       staticBitsets: asciiBitsets,
       staticConsumeFunctions: consumeFunctions,
       staticTransformFunctions: transformFunctions,

--- a/Sources/_StringProcessing/Engine/MEProgram.swift
+++ b/Sources/_StringProcessing/Engine/MEProgram.swift
@@ -23,7 +23,7 @@ struct MEProgram {
   var instructions: InstructionList<Instruction>
 
   var staticElements: [Input.Element]
-  var staticSequences: [[Input.Element]]
+  var staticUTF8Contents: [[UInt8]]
   var staticBitsets: [DSLTree.CustomCharacterClass.AsciiBitset]
   var staticConsumeFunctions: [ConsumeFunction]
   var staticTransformFunctions: [TransformFunction]

--- a/Sources/_StringProcessing/Engine/Registers.swift
+++ b/Sources/_StringProcessing/Engine/Registers.swift
@@ -24,11 +24,9 @@ extension Processor {
     // Verbatim elements to compare against
     var elements: [Element]
 
-    // Verbatim sequences to compare against
-    //
-    // TODO: Degenericize Processor and store Strings
-    var sequences: [[Element]] = []
-    
+    // Verbatim bytes to compare against
+    var utf8Contents: [[UInt8]]
+
     var bitsets: [DSLTree.CustomCharacterClass.AsciiBitset]
 
     var consumeFunctions: [MEProgram.ConsumeFunction]
@@ -55,9 +53,6 @@ extension Processor {
 extension Processor.Registers {
   typealias Input = String
 
-  subscript(_ i: SequenceRegister) -> [Input.Element] {
-    sequences[i.rawValue]
-  }
   subscript(_ i: IntRegister) -> Int {
     get { ints[i.rawValue] }
     set {
@@ -81,6 +76,9 @@ extension Processor.Registers {
   }
   subscript(_ i: ElementRegister) -> Input.Element {
     elements[i.rawValue]
+  }
+  subscript(_ i: UTF8Register) -> [UInt8] {
+    utf8Contents[i.rawValue]
   }
   subscript(
     _ i: AsciiBitsetRegister
@@ -110,8 +108,8 @@ extension Processor.Registers {
     self.elements = program.staticElements
     assert(elements.count == info.elements)
 
-    self.sequences = program.staticSequences
-    assert(sequences.count == info.sequences)
+    self.utf8Contents = program.staticUTF8Contents
+    assert(utf8Contents.count == info.utf8Contents)
 
     self.bitsets = program.staticBitsets
     assert(bitsets.count == info.bitsets)
@@ -156,7 +154,7 @@ extension MutableCollection {
 extension MEProgram {
   struct RegisterInfo {
     var elements = 0
-    var sequences = 0
+    var utf8Contents = 0
     var bools = 0
     var strings = 0
     var bitsets = 0

--- a/Sources/_StringProcessing/MatchingOptions.swift
+++ b/Sources/_StringProcessing/MatchingOptions.swift
@@ -125,7 +125,15 @@ extension MatchingOptions {
       ? .graphemeCluster
       : .unicodeScalar
   }
-  
+
+  /// Whether matching needs to honor canonical equivalence.
+  ///
+  /// Currently, this is synonymous with grapheme-cluster semantics, but could
+  /// become its own option in the future
+  var usesCanonicalEquivalence: Bool {
+    semanticLevel == .graphemeCluster
+  }
+
   var usesNSRECompatibleDot: Bool {
     stack.last!.contains(.nsreCompatibleDot)
   }

--- a/Sources/_StringProcessing/Utility/TypedInt.swift
+++ b/Sources/_StringProcessing/Utility/TypedInt.swift
@@ -122,8 +122,9 @@ enum _SavePointAddress {}
 typealias ElementRegister = TypedInt<_ElementRegister>
 enum _ElementRegister {}
 
-typealias SequenceRegister = TypedInt<_SequenceRegister>
-enum _SequenceRegister {}
+/// The register number for a sequence of UTF-8 bytes
+typealias UTF8Register = TypedInt<_UTF8Register>
+enum _UTF8Register {}
 
 /// The register number for a stored boolean value
 ///

--- a/Tests/RegexTests/CompileTests.swift
+++ b/Tests/RegexTests/CompileTests.swift
@@ -41,6 +41,7 @@ enum DecodedInstr {
   case matchAnyNonNewline
   case matchBitset
   case matchBuiltin
+  case matchUTF8
   case consumeBy
   case assertBy
   case matchBy
@@ -141,6 +142,8 @@ extension DecodedInstr {
       return .captureValue
     case .matchBuiltin:
       return .matchBuiltin
+    case .matchUTF8:
+      return .matchUTF8
     }
   }
 }
@@ -443,10 +446,30 @@ extension RegexTests {
       contains: [.matchScalarUnchecked],
       doesNotContain: [.match, .consumeBy, .matchScalar])
     expectProgram(
-      for: "aaa\u{301}",
+      for: "a\u{301}",
       semanticLevel: .unicodeScalar,
       contains: [.matchScalarUnchecked],
       doesNotContain: [.match, .consumeBy, .matchScalar])
+    expectProgram(
+      for: "abcdefg",
+      semanticLevel: .unicodeScalar,
+      contains: [.matchUTF8],
+      doesNotContain: [.match, .consumeBy, .matchScalar])
+    expectProgram(
+      for: "abcdefg",
+      semanticLevel: .graphemeCluster,
+      contains: [.matchUTF8],
+      doesNotContain: [.match, .consumeBy, .matchScalar])
+    expectProgram(
+      for: "aaa\u{301}",
+      semanticLevel: .unicodeScalar,
+      contains: [.matchUTF8],
+      doesNotContain: [.match, .consumeBy, .matchScalar])
+    expectProgram(
+      for: "aaa\u{301}",
+      semanticLevel: .graphemeCluster,
+      contains: [.match],
+      doesNotContain: [.matchUTF8, .consumeBy])
   }
   
   func testCaseInsensitivityCompilation() {


### PR DESCRIPTION
Adds a new instruction to match a sequence of UTF-8 bytes directly, rather than individual match-scalar calls.