### PR TITLE
[build] Add missing source file to CMake

### DIFF
--- a/Sources/_StringProcessing/CMakeLists.txt
+++ b/Sources/_StringProcessing/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(_StringProcessing
   Algorithms/Algorithms/Replace.swift
   Algorithms/Algorithms/Split.swift
   Algorithms/Algorithms/StartsWith.swift
+  Algorithms/Algorithms/SubstringSearcher.swift
   Algorithms/Algorithms/Trim.swift
   Algorithms/Consumers/CollectionConsumer.swift
   Algorithms/Consumers/FixedPatternConsumer.swift


### PR DESCRIPTION
`SubstringSearcher.swift` wasn't in the list of source files for CMake target _StringProcessing, which caused a compilation error for me locally while building the Swift compiler.