### PR TITLE
Fix repeated case-insensitive ASCII match

### DIFF
--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -2193,6 +2193,25 @@ extension RegexTests {
       ("cafe", true),
       ("CaFe", true),
       ("EfAc", true))
+    
+    matchTest(
+      #"(?i)a+b"#,
+      ("ab", true),
+      ("Ab", true),
+      ("aB", true),
+      ("AB", true))
+    matchTest(
+      #"(?i)a?b"#,
+      ("ab", true),
+      ("Ab", true),
+      ("aB", true),
+      ("AB", true))
+    matchTest(
+      #"(?i)[a]?b"#,
+      ("ab", true),
+      ("Ab", true),
+      ("aB", true),
+      ("AB", true))
   }
 
   func testNonSemanticWhitespace() {

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -2199,19 +2199,35 @@ extension RegexTests {
       ("ab", true),
       ("Ab", true),
       ("aB", true),
-      ("AB", true))
+      ("AB", true),
+      ("AaAab", true),
+      ("aaaAB", true))
     matchTest(
-      #"(?i)a?b"#,
+      #"^(?i)a?b$"#,
       ("ab", true),
       ("Ab", true),
       ("aB", true),
-      ("AB", true))
+      ("AB", true),
+      ("aaB", false),
+      ("b", true),
+      ("B", true))
     matchTest(
-      #"(?i)[a]?b"#,
+      #"^(?i)[a]?b$"#,
       ("ab", true),
       ("Ab", true),
       ("aB", true),
-      ("AB", true))
+      ("AB", true),
+      ("b", true),
+      ("B", true))
+    matchTest(
+      #"^(?i)a{2,4}b$"#,
+      ("ab", false),
+      ("Ab", false),
+      ("AaB", true),
+      ("aAB", true),
+      ("aAaB", true),
+      ("aAaAB", true),
+      ("AaAaAB", false))
   }
 
   func testNonSemanticWhitespace() {


### PR DESCRIPTION
The optimized bytecode for matching repetition of a single character overlooks case insensitivity. This resolves that by falling back to use an ASCII bitset when doing a case-insensitive match of a cased character.

Fixes #785.