### PR TITLE
[6.1] Fix repeated case-insensitive ASCII match

### DIFF
--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -2193,6 +2193,41 @@ extension RegexTests {
       ("cafe", true),
       ("CaFe", true),
       ("EfAc", true))
+    
+    matchTest(
+      #"(?i)a+b"#,
+      ("ab", true),
+      ("Ab", true),
+      ("aB", true),
+      ("AB", true),
+      ("AaAab", true),
+      ("aaaAB", true))
+    matchTest(
+      #"^(?i)a?b$"#,
+      ("ab", true),
+      ("Ab", true),
+      ("aB", true),
+      ("AB", true),
+      ("aaB", false),
+      ("b", true),
+      ("B", true))
+    matchTest(
+      #"^(?i)[a]?b$"#,
+      ("ab", true),
+      ("Ab", true),
+      ("aB", true),
+      ("AB", true),
+      ("b", true),
+      ("B", true))
+    matchTest(
+      #"^(?i)a{2,4}b$"#,
+      ("ab", false),
+      ("Ab", false),
+      ("AaB", true),
+      ("aAB", true),
+      ("aAaB", true),
+      ("aAaAB", true),
+      ("AaAaAB", false))
   }
 
   func testNonSemanticWhitespace() {


### PR DESCRIPTION
Cherry pick of #797 for the `swift/release/6.1` branch.