### PR TITLE
Fix compilation failure if PROCESSOR_MEASUREMENTS_ENABLED is enabled.

### DIFF
--- a/Sources/_StringProcessing/Executor.swift
+++ b/Sources/_StringProcessing/Executor.swift
@@ -212,7 +212,7 @@ extension Executor {
 extension Processor {
   fileprivate mutating func run() throws -> Input.Index? {
 #if PROCESSOR_MEASUREMENTS_ENABLED
-    defer { if cpu.metrics.shouldMeasureMetrics { cpu.printMetrics() } }
+    defer { if metrics.shouldMeasureMetrics { printMetrics() } }
 #endif
     if self.state == .fail {
       if let e = failureReason {


### PR DESCRIPTION
Fixes a compilation failure when building with `PROCESSOR_MEASUREMENTS_ENABLED` enabled. This function is implemented as an extension of `Processor`, so no need to use the `cpu` variable.