### PR TITLE
[6.2] Work around word breaking issue

### DIFF
--- a/Sources/_StringProcessing/Unicode/WordBreaking.swift
+++ b/Sources/_StringProcessing/Unicode/WordBreaking.swift
@@ -87,7 +87,10 @@ extension String {
       var j = maxIndex ?? range.lowerBound
       
       while j < range.upperBound, j <= i {
-        cache!.insert(j)
+        // Workaround for underlying issue in https://github.com/swiftlang/swift-experimental-string-processing/issues/818
+        let (inserted, _) = cache!.insert(j)
+        guard inserted else { return true }
+        
         j = _wordIndex(after: j)
       }
       

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1946,6 +1946,22 @@ extension RegexDSLTests {
     XCTAssertEqual(anyOutput[15].value as? Int, 123)
     XCTAssertEqual(anyOutput[16].substring, "456")
   }
+  
+  func testIssue818() throws {
+    // Original report from https://github.com/swiftlang/swift-experimental-string-processing/issues/818
+    let clip = "⁠‘⁠⁠example.com⁠⁠’"
+    let clip2 = "\u{2060}\u{2018}\u{2060}\u{2060}example.com\u{2060}\u{2060}\u{2019}"
+    assert(clip.unicodeScalars.elementsEqual(clip2.unicodeScalars))
+    
+    let pattern = Regex {
+      Anchor.wordBoundary     // line A
+      "example"
+      Anchor.wordBoundary     // line B
+    }
+    
+    XCTAssertNotNil(clip.contains(pattern))
+    XCTAssertNotNil(clip2.contains(pattern))
+  }
 }
 
 extension Unicode.Scalar {


### PR DESCRIPTION
Cherry pick of #819 for 6.2 branch.

---

- **Explanation:** Handles an erroneous result from the stdlib's `_wordIndex(after:)` method, which for certain strings can return an index before its parameter. This change detects and returns from a loop when it receives a previously cached index.
- **Risk:** Low. Only affects regex matching for certain regex patterns.
- **Testing:** Tested by string-processing unit tests; added a new test for the specific issue.
- **Reviewed By:** @stephentyrone 
- **Problem:** rdar://154903905
- **Original PR:** #819