### PR TITLE
Include optionality in AnyRegexOutput.Element.type

### DIFF
--- a/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
+++ b/Sources/_StringProcessing/Regex/AnyRegexOutput.swift
@@ -381,7 +381,12 @@ extension AnyRegexOutput.ElementRepresentation {
   }
 
   var type: Any.Type {
-    content?.value.map { Swift.type(of: $0) }
-      ?? TypeConstruction.optionalType(of: Substring.self, depth: optionalDepth)
+    func wrapIfNecessary<U>(_: U.Type) -> Any.Type {
+      TypeConstruction.optionalType(of: U.self, depth: optionalDepth)
+    }
+
+    return content?.value.map {
+      _openExistential(Swift.type(of: $0), do: wrapIfNecessary)
+    } ?? TypeConstruction.optionalType(of: Substring.self, depth: optionalDepth)
   }
 }

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1979,10 +1979,10 @@ extension RegexDSLTests {
            OneOrMore(.digit)
        } transform: { Int($0)! }
        "/"
-       // denominator
+       // denominator (modified to test for double optional)
        Capture {
            OneOrMore(.digit)
-       } transform: { Int($0)! }
+       } transform: { Optional.some(Int($0)) }
     }
     
     do {
@@ -1995,7 +1995,7 @@ extension RegexDSLTests {
       XCTAssert(erasedMatch.output[0].type == Substring.self)
       XCTAssert(erasedMatch.output[1].type == Int?.self)
       XCTAssert(erasedMatch.output[2].type == Int.self)
-      XCTAssert(erasedMatch.output[3].type == Int.self)
+      XCTAssert(erasedMatch.output[3].type == Int??.self)
     }
 
     do {
@@ -2007,7 +2007,7 @@ extension RegexDSLTests {
       let erasedMatch = Regex<AnyRegexOutput>.Match(match)
       XCTAssert(erasedMatch.output[0].type == Substring.self)
       XCTAssert(erasedMatch.output[2].type == Int.self)
-      XCTAssert(erasedMatch.output[3].type == Int.self)
+      XCTAssert(erasedMatch.output[3].type == Int??.self)
 
       XCTExpectFailure {
         // `nil` value is interpreted as `Substring?` instead of `Int?`

--- a/Tests/RegexBuilderTests/RegexDSLTests.swift
+++ b/Tests/RegexBuilderTests/RegexDSLTests.swift
@@ -1962,6 +1962,59 @@ extension RegexDSLTests {
     XCTAssertNotNil(clip.contains(pattern))
     XCTAssertNotNil(clip2.contains(pattern))
   }
+  
+  func testIssue83022() throws {
+    // Original report from https://github.com/swiftlang/swift/issues/83022
+    // rdar://155710126
+    let mixedNumberRegex = Regex {
+       // whole number
+       Optionally {
+           Capture {
+               OneOrMore(.digit)
+           } transform: { Int($0)! }
+           OneOrMore { " " }
+       }
+       // numerator
+       Capture {
+           OneOrMore(.digit)
+       } transform: { Int($0)! }
+       "/"
+       // denominator
+       Capture {
+           OneOrMore(.digit)
+       } transform: { Int($0)! }
+    }
+    
+    do {
+      let match = try XCTUnwrap(mixedNumberRegex.wholeMatch(in: "1 3/4"))
+      XCTAssertEqual(match.1, 1)
+      XCTAssertEqual(match.2, 3)
+      XCTAssertEqual(match.3, 4)
+      
+      let erasedMatch = Regex<AnyRegexOutput>.Match(match)
+      XCTAssert(erasedMatch.output[0].type == Substring.self)
+      XCTAssert(erasedMatch.output[1].type == Int?.self)
+      XCTAssert(erasedMatch.output[2].type == Int.self)
+      XCTAssert(erasedMatch.output[3].type == Int.self)
+    }
+
+    do {
+      let match = try XCTUnwrap(mixedNumberRegex.wholeMatch(in: "3/4"))
+      XCTAssertNil(match.1)
+      XCTAssertEqual(match.2, 3)
+      XCTAssertEqual(match.3, 4)
+      
+      let erasedMatch = Regex<AnyRegexOutput>.Match(match)
+      XCTAssert(erasedMatch.output[0].type == Substring.self)
+      XCTAssert(erasedMatch.output[2].type == Int.self)
+      XCTAssert(erasedMatch.output[3].type == Int.self)
+
+      XCTExpectFailure {
+        // `nil` value is interpreted as `Substring?` instead of `Int?`
+        XCTAssert(erasedMatch.output[1].type == Int?.self)
+      }
+    }
+  }
 }
 
 extension Unicode.Scalar {


### PR DESCRIPTION
When reconstructing the type of a captured element for access through the `AnyRegexOutput.Element.type` API, any optionality is being omitted (e.g. `Int?` is returned as `Int`). This is both observable through that API and results in a bug when accessing part of a match's output through the dynamic member subscript (e.g. `match.1`).

In that case, the lack of optionality causes an incorrect calculation of the output tuple member's position, resulting in the wrong member being loaded and returned.

This change adds the missing optionality to the type.

Fixes https://github.com/swiftlang/swift/issues/83022. (rdar://155710126)
