### PR TITLE
Make CCC compilation deterministic

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -940,20 +940,26 @@ fileprivate extension Compiler.ByteCodeGen {
       case .atom(let atom):
         switch atom {
         case let .char(char):
-          characters.insert(char)
+          if characters.insert(char).inserted {
+            result.append(member)
+          }
         case let .scalar(scalar):
-          scalars.insert(scalar)
+          if scalars.insert(scalar).inserted {
+            result.append(member)
+          }
         default:
           result.append(member)
         }
       case let .quotedLiteral(str):
-        characters.formUnion(str)
+        for char in str {
+          if characters.insert(char).inserted {
+            result.append(.atom(.char(char)))
+          }
+        }
       default:
         result.append(member)
       }
     }
-    result.append(contentsOf: characters.map { .atom(.char($0)) })
-    result.append(contentsOf: scalars.map { .atom(.scalar($0)) })
     return result
   }
   

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -2864,6 +2864,18 @@ extension RegexTests {
     XCTAssertNil(additionalInput.wholeMatch(of: additionalRegex))
   }
   
+  func testIssueSwift81427() throws {
+    // This issue is a nondeterministic matching failure, where this character
+    // set is occasionally compiled incorrectly. Multiple test runs (not just
+    // multiple executions of this test) are required for verification.
+    firstMatchTests(
+      "[(?:\r\n)\n\r]",
+      ("\n", "\n"),
+      ("\r", "\r"),
+      ("\r\n", "\r\n")
+    )
+  }
+  
   func testNSRECompatibility() throws {
     // NSRE-compatibility includes scalar matching, so `[\r\n]` should match
     // either `\r` or `\n`.


### PR DESCRIPTION
This fixes an issue where using a set to unique the elements of a CCC led to a nondeterministic ordering, which could then lead to unexpected coalescing of separate scalars into a single character. (e.g. `[\nA\r]` -> `["\r", "\n", "A"]` -> `["\r\n", "A"]`)

This change keeps the order of the original CCC, so coalescing into characters should not occur unless the scalars are already in that order.

Fixes https://github.com/swiftlang/swift/issues/81427. (rdar://151046715)