### PR TITLE
Start of line in negative lookahead optimization fix

### DIFF
--- a/Sources/_StringProcessing/Regex/DSLTree.swift
+++ b/Sources/_StringProcessing/Regex/DSLTree.swift
@@ -791,6 +791,10 @@ extension DSLTree.Node {
 
     // Groups (and other parent nodes) defer to the child.
     case .nonCapturingGroup(let kind, let child):
+      // Don't let a negative lookahead affect this - need to continue to next sibling
+      if kind.isNegativeLookahead {
+        return nil
+      }
       options.beginScope()
       defer { options.endScope() }
       if case .changeMatchingOptions(let sequence) = kind.ast {
@@ -901,6 +905,10 @@ extension DSLTree {
       }
       public static var negativeLookahead: Self {
         .init(ast: .negativeLookahead)
+      }
+      
+      internal var isNegativeLookahead: Bool {
+        self.ast == .negativeLookahead
       }
     }
 

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -46,7 +46,7 @@ func _firstMatch(
 ) throws -> (String, [String?])? {
   var regex = try Regex(regexStr, syntax: syntax).matchingSemantics(semanticLevel)
   let result = try regex.firstMatch(in: input)
-  
+
   func validateSubstring(_ substringInput: Substring) throws {
     // Sometimes the characters we add to a substring merge with existing
     // string members. This messes up cross-validation, so skip the test.
@@ -1629,6 +1629,14 @@ extension RegexTests {
     // engines generally enforce that lookbehinds are fixed width
     firstMatchTest(
       #"\d{3}(?<!USD\d{3})"#, input: "Price: JYP100", match: "100", xfail: true)
+    
+    // Assertions inside negative lookahead
+    firstMatchTest(
+      #"(?!\b)(With)"#, input: "dispatchWithName", match: "With")
+    firstMatchTest(
+      #"(?!^)(With)"#, input: "dispatchWithName", match: "With")
+    firstMatchTest(
+      #"(?!\s)^dispatch"#, input: "dispatchWithName", match: "dispatch")
   }
 
   func testMatchAnchors() throws {
@@ -2874,6 +2882,11 @@ extension RegexTests {
       ("\r", "\r"),
       ("\r\n", "\r\n")
     )
+  }
+
+  func testIssue81789() throws {
+    let matches = "dispatchWithName".matches(of: #/(?!^)(With(?!No)|For|In|At|To)(?=[A-Z])/#)
+    XCTAssert(matches[0].output == ("With", "With"))
   }
   
   func testNSRECompatibility() throws {


### PR DESCRIPTION
Don't use the content of negative lookaheads when determining whether a start-of-line assertion can require that match has to start at the beginning of the subject.

Fixes https://github.com/swiftlang/swift#81789.
rdar://152119639