### PR TITLE
[perf] Create a flattened representation of `DSLTree`

### DIFF
--- a/Sources/_StringProcessing/ByteCodeGen+DSLList.swift
+++ b/Sources/_StringProcessing/ByteCodeGen+DSLList.swift
@@ -1,0 +1,723 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+internal import _RegexParser
+
+extension Compiler.ByteCodeGen {
+  mutating func emitRoot(_ root: DSLList) throws -> MEProgram {
+    // If the whole regex is a matcher, then the whole-match value
+    // is the constructed value. Denote that the current value
+    // register is the processor's value output.
+    switch root.nodes.first {
+    case .matcher:
+      builder.denoteCurrentValueIsWholeMatchValue()
+    default:
+      break
+    }
+
+    var list = root.nodes[...]
+    try emitNode(&list)
+
+    // FIXME: Restore this canOnlyMatchAtStart
+    // builder.canOnlyMatchAtStart = root.canOnlyMatchAtStart()
+    builder.buildAccept()
+    return try builder.assemble()
+  }
+}
+
+fileprivate extension Compiler.ByteCodeGen {
+  mutating func emitAlternationGen<T>(
+    _ elements: inout ArraySlice<T>,
+    alternationCount: Int,
+    withBacktracking: Bool,
+    _ body: (inout Compiler.ByteCodeGen, inout ArraySlice<T>) throws -> Void
+  ) rethrows {
+    // Alternation: p0 | p1 | ... | pn
+    //     save next_p1
+    //     <code for p0>
+    //     branch done
+    //   next_p1:
+    //     save next_p2
+    //     <code for p1>
+    //     branch done
+    //   next_p2:
+    //     save next_p...
+    //     <code for p2>
+    //     branch done
+    //   ...
+    //   next_pn:
+    //     <code for pn>
+    //   done:
+    let done = builder.makeAddress()
+    for _ in 1..<alternationCount {
+      let next = builder.makeAddress()
+      builder.buildSave(next)
+      try body(&self, &elements)
+      if !withBacktracking {
+        builder.buildClear()
+      }
+      builder.buildBranch(to: done)
+      builder.label(next)
+    }
+    try body(&self, &elements)
+    builder.label(done)
+  }
+  
+  mutating func emitAlternation(
+    _ list: inout ArraySlice<DSLTree.Node>,
+    alternationCount count: Int
+  ) throws {
+    try emitAlternationGen(&list, alternationCount: count, withBacktracking: true) {
+      try $0.emitNode(&$1)
+    }
+  }
+
+  mutating func emitPositiveLookahead(_ list: inout ArraySlice<DSLTree.Node>) throws {
+    /*
+      save(restoringAt: success)
+      save(restoringAt: intercept)
+      <sub-pattern>    // failure restores at intercept
+      clearThrough(intercept)       // remove intercept and any leftovers from <sub-pattern>
+     fail(preservingCaptures: true) // ->success
+    intercept:
+      clearSavePoint   // remove success
+      fail             // propagate failure
+    success:
+      ...
+    */
+    let intercept = builder.makeAddress()
+    let success = builder.makeAddress()
+
+    builder.buildSave(success)
+    builder.buildSave(intercept)
+    try emitNode(&list)
+    builder.buildClearThrough(intercept)
+    builder.buildFail(preservingCaptures: true) // Lookahead succeeds here
+
+    builder.label(intercept)
+    builder.buildClear()
+    builder.buildFail()
+
+    builder.label(success)
+  }
+  
+  mutating func emitNegativeLookahead(_ list: inout ArraySlice<DSLTree.Node>) throws {
+    /*
+      save(restoringAt: success)
+      save(restoringAt: intercept)
+      <sub-pattern>    // failure restores at intercept
+      clearThrough(intercept) // remove intercept and any leftovers from <sub-pattern>
+      clearSavePoint   // remove success
+      fail             // propagate failure
+    intercept:
+      fail             // ->success
+    success:
+      ...
+    */
+    let intercept = builder.makeAddress()
+    let success = builder.makeAddress()
+
+    builder.buildSave(success)
+    builder.buildSave(intercept)
+    try emitNode(&list)
+    builder.buildClearThrough(intercept)
+    builder.buildClear()
+    builder.buildFail()
+
+    builder.label(intercept)
+    builder.buildFail()
+
+    builder.label(success)
+  }
+  
+  mutating func emitLookaround(
+    _ kind: (forwards: Bool, positive: Bool),
+    _ list: inout ArraySlice<DSLTree.Node>
+  ) throws {
+    guard kind.forwards else {
+      throw Unsupported("backwards assertions")
+    }
+    if kind.positive {
+      try emitPositiveLookahead(&list)
+    } else {
+      try emitNegativeLookahead(&list)
+    }
+  }
+
+  mutating func emitAtomicNoncapturingGroup(
+    _ list: inout ArraySlice<DSLTree.Node>
+  ) throws {
+    /*
+      save(continuingAt: success)
+      save(restoringAt: intercept)
+      <sub-pattern>    // failure restores at intercept
+      clearThrough(intercept)        // remove intercept and any leftovers from <sub-pattern>
+      fail(preservingCaptures: true) // ->success
+    intercept:
+      clearSavePoint   // remove success
+      fail             // propagate failure
+    success:
+      ...
+    */
+
+    let intercept = builder.makeAddress()
+    let success = builder.makeAddress()
+
+    builder.buildSaveAddress(success)
+    builder.buildSave(intercept)
+    try emitNode(&list)
+    builder.buildClearThrough(intercept)
+    builder.buildFail(preservingCaptures: true) // Atomic group succeeds here
+
+    builder.label(intercept)
+    builder.buildClear()
+    builder.buildFail()
+
+    builder.label(success)
+  }
+
+  mutating func emitNoncapturingGroup(
+    _ kind: AST.Group.Kind,
+    _ list: inout ArraySlice<DSLTree.Node>
+  ) throws {
+    assert(!kind.isCapturing)
+
+    options.beginScope()
+    defer { options.endScope() }
+
+    if let lookaround = kind.lookaroundKind {
+      try emitLookaround(lookaround, &list)
+      return
+    }
+
+    switch kind {
+    case .lookahead, .negativeLookahead,
+        .lookbehind, .negativeLookbehind:
+      throw Unreachable("TODO: reason")
+
+    case .capture, .namedCapture, .balancedCapture:
+      throw Unreachable("These should produce a capture node")
+
+    case .changeMatchingOptions(let optionSequence):
+      if !hasEmittedFirstMatchableAtom {
+        builder.initialOptions.apply(optionSequence)
+      }
+      options.apply(optionSequence)
+      try emitNode(&list)
+      
+    case .atomicNonCapturing:
+      try emitAtomicNoncapturingGroup(&list)
+
+    default:
+      // FIXME: Other kinds...
+      try emitNode(&list)
+    }
+  }
+
+  mutating func emitQuantification(
+    _ amount: AST.Quantification.Amount,
+    _ kind: DSLTree.QuantificationKind,
+    _ list: inout ArraySlice<DSLTree.Node>
+  ) throws {
+    let updatedKind: AST.Quantification.Kind
+    switch kind {
+    case .explicit(let kind):
+      updatedKind = kind.ast
+    case .syntax(let kind):
+      updatedKind = kind.ast.applying(options)
+    case .default:
+      updatedKind = options.defaultQuantificationKind
+    }
+
+    let (low, high) = amount.bounds
+    guard let low = low else {
+      throw Unreachable("Must have a lower bound")
+    }
+    switch (low, high) {
+    case (_, 0):
+      try skipNode(&list)
+      return
+    case let (n, m?) where n > m:
+      // TODO: Should error out earlier, maybe DSL and parser
+      // has validation logic?
+      return
+
+    case let (n, m) where m == nil || n <= m!:
+      // Ok
+      break
+    default:
+      throw Unreachable("TODO: reason")
+    }
+
+    // Compiler and/or parser should enforce these invariants
+    // before we are called
+    assert(high != 0)
+    assert((0...(high ?? Int.max)).contains(low))
+
+    let maxExtraTrips: Int?
+    if let h = high {
+      maxExtraTrips = h - low
+    } else {
+      maxExtraTrips = nil
+    }
+    let minTrips = low
+    assert((maxExtraTrips ?? 1) >= 0)
+
+    var tmp = list
+    if tryEmitFastQuant(&tmp, updatedKind, minTrips, maxExtraTrips) {
+      list = tmp
+      return
+    }
+
+    // The below is a general algorithm for bounded and unbounded
+    // quantification. It can be specialized when the min
+    // is 0 or 1, or when extra trips is 1 or unbounded.
+    //
+    // Stuff inside `<` and `>` are decided at compile time,
+    // while run-time values stored in registers start with a `%`
+    _ = """
+      min-trip-count control block:
+        if %minTrips is zero:
+          goto exit-policy control block
+        else:
+          decrement %minTrips and fallthrough
+
+      loop-body:
+        <if can't guarantee forward progress && maxExtraTrips = nil>:
+          mov currentPosition %pos
+        evaluate the subexpression
+        <if can't guarantee forward progress && maxExtraTrips = nil>:
+          if %pos is currentPosition:
+            goto exit
+        goto min-trip-count control block
+
+      exit-policy control block:
+        if %maxExtraTrips is zero:
+          goto exit
+        else:
+          decrement %maxExtraTrips and fallthrough
+
+        <if eager>:
+          save exit and goto loop-body
+        <if possessive>:
+          ratchet and goto loop
+        <if reluctant>:
+          save loop-body and fallthrough (i.e. goto exit)
+
+      exit
+        ... the rest of the program ...
+    """
+
+    // Specialization based on `minTrips` for 0 or 1:
+    _ = """
+      min-trip-count control block:
+        <if minTrips == 0>:
+          goto exit-policy
+        <if minTrips == 1>:
+          /* fallthrough */
+
+      loop-body:
+        evaluate the subexpression
+        <if minTrips <= 1>
+          /* fallthrough */
+    """
+
+    // Specialization based on `maxExtraTrips` for 0 or unbounded
+    _ = """
+      exit-policy control block:
+        <if maxExtraTrips == 0>:
+          goto exit
+        <if maxExtraTrips == .unbounded>:
+          /* fallthrough */
+    """
+
+    /*
+      NOTE: These specializations don't emit the optimal
+      code layout (e.g. fallthrough vs goto), but that's better
+      done later (not prematurely) and certainly better
+      done by an optimizing compiler.
+
+      NOTE: We're intentionally emitting essentially the same
+      algorithm for all quantifications for now, for better
+      testing and surfacing difficult bugs. We can specialize
+      for other things, like `.*`, later.
+
+      When it comes time for optimizing, we can also look into
+      quantification instructions (e.g. reduce save-point traffic)
+    */
+
+    let minTripsControl = builder.makeAddress()
+    let loopBody = builder.makeAddress()
+    let exitPolicy = builder.makeAddress()
+    let exit = builder.makeAddress()
+
+    // We'll need registers if we're (non-trivially) bounded
+    let minTripsReg: IntRegister?
+    if minTrips > 1 {
+      minTripsReg = builder.makeIntRegister(
+        initialValue: minTrips)
+    } else {
+      minTripsReg = nil
+    }
+
+    let maxExtraTripsReg: IntRegister?
+    if (maxExtraTrips ?? 0) > 0 {
+      maxExtraTripsReg = builder.makeIntRegister(
+        initialValue: maxExtraTrips!)
+    } else {
+      maxExtraTripsReg = nil
+    }
+
+    // Set up a dummy save point for possessive to update
+    if updatedKind == .possessive {
+      builder.pushEmptySavePoint()
+    }
+
+    // min-trip-count:
+    //   condBranch(to: exitPolicy, ifZeroElseDecrement: %min)
+    builder.label(minTripsControl)
+    switch minTrips {
+    case 0: builder.buildBranch(to: exitPolicy)
+    case 1: break
+    default:
+      assert(minTripsReg != nil, "logic inconsistency")
+      builder.buildCondBranch(
+        to: exitPolicy, ifZeroElseDecrement: minTripsReg!)
+    }
+
+    // FIXME: Possessive needs a "dummy" save point to ratchet
+
+    // loop:
+    //   <subexpression>
+    //   branch min-trip-count
+    builder.label(loopBody)
+
+    // if we aren't sure if the child node will have forward progress and
+    // we have an unbounded quantification
+    let startPosition: PositionRegister?
+    // FIXME: forward progress check?!
+    let emitPositionChecking =
+      (!optimizationsEnabled || (list.first?.guaranteesForwardProgress != true)) &&
+      maxExtraTrips == nil
+
+    if emitPositionChecking {
+      startPosition = builder.makePositionRegister()
+      builder.buildMoveCurrentPosition(into: startPosition!)
+    } else {
+      startPosition = nil
+    }
+    try emitNode(&list)
+    if emitPositionChecking {
+      // in all quantifier cases, no matter what minTrips or maxExtraTrips is,
+      // if we have a successful non-advancing match, branch to exit because it
+      // can match an arbitrary number of times
+      builder.buildCondBranch(to: exit, ifSamePositionAs: startPosition!)
+    }
+
+    if minTrips <= 1 {
+      // fallthrough
+    } else {
+      builder.buildBranch(to: minTripsControl)
+    }
+
+    // exit-policy:
+    //   condBranch(to: exit, ifZeroElseDecrement: %maxExtraTrips)
+    //   <eager: split(to: loop, saving: exit)>
+    //   <possesive:
+    //     clearSavePoint
+    //     split(to: loop, saving: exit)>
+    //   <reluctant: save(restoringAt: loop)
+    builder.label(exitPolicy)
+    switch maxExtraTrips {
+    case nil: break
+    case 0:   builder.buildBranch(to: exit)
+    default:
+      assert(maxExtraTripsReg != nil, "logic inconsistency")
+      builder.buildCondBranch(
+        to: exit, ifZeroElseDecrement: maxExtraTripsReg!)
+    }
+
+    switch updatedKind {
+    case .eager:
+      builder.buildSplit(to: loopBody, saving: exit)
+    case .possessive:
+      builder.buildClear()
+      builder.buildSplit(to: loopBody, saving: exit)
+    case .reluctant:
+      builder.buildSave(loopBody)
+      // FIXME: Is this re-entrant? That is would nested
+      // quantification break if trying to restore to a prior
+      // iteration because the register got overwritten?
+      //
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError()
+    #endif
+    }
+
+    builder.label(exit)
+  }
+
+  /// Specialized quantification instruction for repetition of certain nodes in grapheme semantic mode
+  /// Allowed nodes are:
+  /// - single ascii scalar .char
+  /// - ascii .customCharacterClass
+  /// - single grapheme consumgin built in character classes
+  /// - .any, .anyNonNewline, .dot
+  mutating func tryEmitFastQuant(
+    _ list: inout ArraySlice<DSLTree.Node>,
+    _ kind: AST.Quantification.Kind,
+    _ minTrips: Int,
+    _ maxExtraTrips: Int?
+  ) -> Bool {
+    let isScalarSemantics = options.semanticLevel == .unicodeScalar
+    guard optimizationsEnabled
+            && minTrips <= QuantifyPayload.maxStorableTrips
+            && maxExtraTrips ?? 0 <= QuantifyPayload.maxStorableTrips
+            && kind != .reluctant else {
+      return false
+    }
+    guard let child = list.popFirst() else { return false }
+    
+    switch child {
+    case .customCharacterClass(let ccc):
+      // ascii only custom character class
+      guard let bitset = ccc.asAsciiBitset(options) else {
+        return false
+      }
+      builder.buildQuantify(bitset: bitset, kind, minTrips, maxExtraTrips, isScalarSemantics: isScalarSemantics)
+
+    case .atom(let atom):
+      switch atom {
+      case .char(let c):
+        if options.isCaseInsensitive && c.isCased {
+          // Cased character with case-insensitive matching; match only as an ASCII bitset
+          guard let bitset = DSLTree.CustomCharacterClass(members: [.atom(atom)]).asAsciiBitset(options) else {
+            return false
+          }
+          builder.buildQuantify(bitset: bitset, kind, minTrips, maxExtraTrips, isScalarSemantics: isScalarSemantics)
+        } else {
+          // Uncased character OR case-sensitive matching; match as a single scalar ascii value character
+          guard let val = c._singleScalarAsciiValue else {
+            return false
+          }
+          builder.buildQuantify(asciiChar: val, kind, minTrips, maxExtraTrips, isScalarSemantics: isScalarSemantics)
+        }
+
+      case .any:
+        builder.buildQuantifyAny(
+          matchesNewlines: true, kind, minTrips, maxExtraTrips, isScalarSemantics: isScalarSemantics)
+      case .anyNonNewline:
+        builder.buildQuantifyAny(
+          matchesNewlines: false, kind, minTrips, maxExtraTrips, isScalarSemantics: isScalarSemantics)
+      case .dot:
+        builder.buildQuantifyAny(
+          matchesNewlines: options.dotMatchesNewline, kind, minTrips, maxExtraTrips, isScalarSemantics: isScalarSemantics)
+
+      case .characterClass(let cc):
+        // Custom character class that consumes a single grapheme
+        let model = cc.asRuntimeModel(options)
+        builder.buildQuantify(
+          model: model,
+          kind,
+          minTrips,
+          maxExtraTrips,
+          isScalarSemantics: isScalarSemantics)
+      default:
+        return false
+      }
+    case .limitCaptureNesting(let node):
+      if tryEmitFastQuant(&list, kind, minTrips, maxExtraTrips) {
+        return true
+      } else {
+        return false
+      }
+    case .nonCapturingGroup(let groupKind, let node):
+      // .nonCapture nonCapturingGroups are ignored during compilation
+      guard groupKind.ast == .nonCapture else {
+        return false
+      }
+      if tryEmitFastQuant(&list, kind, minTrips, maxExtraTrips) {
+        return true
+      } else {
+        return false
+      }
+    default:
+      return false
+    }
+    return true
+  }
+  
+  mutating func emitConcatenation(
+    _ list: inout ArraySlice<DSLTree.Node>,
+    componentCount: Int
+  ) throws {
+    // Unlike the tree-based bytecode generator, in a DSLList concatenations
+    // have already been flattened.
+    for _ in 0..<componentCount {
+      try emitNode(&list)
+    }
+  }
+
+  @discardableResult
+  mutating func emitNode(_ list: inout ArraySlice<DSLTree.Node>) throws -> ValueRegister? {
+    guard let node = list.popFirst() else { return nil }
+    switch node {
+      
+    case let .orderedChoice(children):
+      let n = children.count
+      try emitAlternation(&list, alternationCount: n)
+      
+    case let .concatenation(children):
+      let n = children.count
+      try emitConcatenation(&list, componentCount: n)
+      
+    case let .capture(name, refId, _, transform):
+      options.beginScope()
+      defer { options.endScope() }
+      
+      let cap = builder.makeCapture(id: refId, name: name)
+      builder.buildBeginCapture(cap)
+      let value = try emitNode(&list)
+      builder.buildEndCapture(cap)
+      // If the child node produced a custom capture value, e.g. the result of
+      // a matcher, this should override the captured substring.
+      if let value {
+        builder.buildMove(value, into: cap)
+      }
+      // If there's a capture transform, apply it now.
+      if let transform = transform {
+        let fn = builder.makeTransformFunction { input, cap in
+          // If it's a substring capture with no custom value, apply the
+          // transform directly to the substring to avoid existential traffic.
+          //
+          // FIXME: separate out this code path. This is fragile,
+          // slow, and these are clearly different constructs
+          if let range = cap.range, cap.value == nil {
+            return try transform(input[range])
+          }
+          
+          let value = constructExistentialOutputComponent(
+            from: input,
+            component: cap.deconstructed,
+            optionalCount: 0)
+          return try transform(value)
+        }
+        builder.buildTransformCapture(cap, fn)
+      }
+      
+    case let .nonCapturingGroup(kind, _):
+      try emitNoncapturingGroup(kind.ast, &list)
+      
+    case let .ignoreCapturesInTypedOutput(_):
+      try emitNode(&list)
+      
+    case let .limitCaptureNesting(_):
+      return try emitNode(&list)
+      
+    case .conditional:
+      throw Unsupported("Conditionals")
+      
+    case let .quantification(amt, kind, _):
+      try emitQuantification(amt.ast, kind, &list)
+      
+    case let .customCharacterClass(ccc):
+      if ccc.containsDot {
+        if !ccc.isInverted {
+          try emitDot()
+        } else {
+          throw Unsupported("Inverted any")
+        }
+      } else {
+        try emitCustomCharacterClass(ccc)
+      }
+      
+    case let .atom(a):
+      try emitAtom(a)
+      
+    case let .quotedLiteral(s):
+      emitQuotedLiteral(s)
+      
+    case .absentFunction:
+      throw Unsupported("absent function")
+    case .consumer:
+      throw Unsupported("consumer")
+      
+    case let .matcher(_, f):
+      return emitMatcher(f)
+      
+    case .characterPredicate:
+      throw Unsupported("character predicates")
+      
+    case .trivia, .empty:
+      return nil
+    }
+    return nil
+  }
+}
+
+// MARK: Skip node
+
+extension Compiler.ByteCodeGen {
+  mutating func skipNode(_ list: inout ArraySlice<DSLTree.Node>) throws {
+    guard let node = list.popFirst() else { return }
+    switch node {
+    case let .orderedChoice(children):
+      let n = children.count
+      for _ in 0..<n {
+        try skipNode(&list)
+      }
+      
+    case let .concatenation(children):
+      let n = children.count
+      for _ in 0..<n {
+        try skipNode(&list)
+      }
+
+    case let .capture(name, refId, _, transform):
+      options.beginScope()
+      defer { options.endScope() }
+      
+      let cap = builder.makeCapture(id: refId, name: name)
+      builder.buildBeginCapture(cap)
+      try skipNode(&list)
+      builder.buildEndCapture(cap)
+      
+    case let .nonCapturingGroup(kind, _):
+      try skipNode(&list)
+
+    case .ignoreCapturesInTypedOutput:
+      try skipNode(&list)
+      
+    case .limitCaptureNesting:
+      try skipNode(&list)
+
+    case let .quantification(amt, kind, _):
+      try skipNode(&list)
+      
+    case .customCharacterClass, .atom, .quotedLiteral, .matcher:
+      break
+      
+    case .conditional:
+      throw Unsupported("Conditionals")
+    case .absentFunction:
+      throw Unsupported("absent function")
+    case .consumer:
+      throw Unsupported("consumer")
+    case .characterPredicate:
+      throw Unsupported("character predicates")
+      
+    case .trivia, .empty:
+      break
+    }
+  }
+
+}

--- a/Sources/_StringProcessing/ByteCodeGen.swift
+++ b/Sources/_StringProcessing/ByteCodeGen.swift
@@ -23,7 +23,7 @@ extension Compiler {
     var hasEmittedFirstMatchableAtom = false
 
     private let compileOptions: _CompileOptions
-    fileprivate var optimizationsEnabled: Bool {
+    internal var optimizationsEnabled: Bool {
       !compileOptions.contains(.disableOptimizations)
     }
 
@@ -61,7 +61,7 @@ extension Compiler.ByteCodeGen {
   }
 }
 
-fileprivate extension Compiler.ByteCodeGen {
+extension Compiler.ByteCodeGen {
   mutating func emitAtom(_ a: DSLTree.Atom) throws {
     defer {
       if a.isMatchable {

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -40,6 +40,20 @@ class Compiler {
       captureList: tree.captureList)
     return try codegen.emitRoot(tree.root)
   }
+  
+  __consuming func emitViaList() throws -> MEProgram {
+    // TODO: Handle global options
+    let dslList = DSLList(tree: tree)
+    for (n, el) in dslList.nodes.enumerated() {
+      print("\(n): \(el)")
+    }
+    var codegen = ByteCodeGen(
+      options: options,
+      compileOptions:
+        compileOptions,
+      captureList: tree.captureList)
+    return try codegen.emitRoot(dslList)
+  }
 }
 
 /// Hashable wrapper for `Any.Type`.

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -44,9 +44,6 @@ class Compiler {
   __consuming func emitViaList() throws -> MEProgram {
     // TODO: Handle global options
     let dslList = DSLList(tree: tree)
-    for (n, el) in dslList.nodes.enumerated() {
-      print("\(n): \(el)")
-    }
     var codegen = ByteCodeGen(
       options: options,
       compileOptions:

--- a/Sources/_StringProcessing/Compiler.swift
+++ b/Sources/_StringProcessing/Compiler.swift
@@ -32,6 +32,10 @@ class Compiler {
   }
 
   __consuming func emit() throws -> MEProgram {
+    try emitViaList()
+  }
+  
+  __consuming func emitViaTree() throws -> MEProgram {
     // TODO: Handle global options
     var codegen = ByteCodeGen(
       options: options,

--- a/Sources/_StringProcessing/LiteralPrinter.swift
+++ b/Sources/_StringProcessing/LiteralPrinter.swift
@@ -116,11 +116,9 @@ extension LiteralPrinter {
       outputNode(child)
       output(")")
       
-    case let .ignoreCapturesInTypedOutput(child):
+    case let .ignoreCapturesInTypedOutput(child),
+         let .limitCaptureNesting(child):
       outputNode(child)
-    case .convertedRegexLiteral(let node, _):
-      outputNode(node)
-
     case let .quantification(amount, kind, node):
       outputQuantification(amount, kind, node)
     case let .customCharacterClass(charClass):

--- a/Sources/_StringProcessing/PrintAsPattern.swift
+++ b/Sources/_StringProcessing/PrintAsPattern.swift
@@ -179,6 +179,9 @@ extension PrettyPrinter {
     case let .ignoreCapturesInTypedOutput(child):
       printAsPattern(convertedFromAST: child, isTopLevel: isTopLevel)
       
+    case let .limitCaptureNesting(child):
+      printAsPattern(convertedFromAST: child, isTopLevel: isTopLevel)
+      
     case .conditional:
       print("/* TODO: conditional */")
 
@@ -258,20 +261,6 @@ extension PrettyPrinter {
           
           break
           
-        case let .convertedRegexLiteral(.atom(a), _):
-          if let pattern = a._patternBase(&self), pattern.canBeWrapped {
-            printAtom(pattern.0)
-            return
-          }
-          
-          break
-        case let .convertedRegexLiteral(.customCharacterClass(ccc), _):
-          if ccc.isSimplePrint {
-            printSimpleCCC(ccc)
-            return
-          }
-          
-          break
         default:
           break
         }
@@ -304,13 +293,6 @@ extension PrettyPrinter {
 
     case let .quotedLiteral(v):
       print(v._quoted)
-
-    case let .convertedRegexLiteral(n, _):
-      // FIXME: This recursion coordinates with back-off
-      // check above, so it should work out. Need a
-      // cleaner way to do this. This means the argument
-      // label is a lie.
-      printAsPattern(convertedFromAST: n, isTopLevel: isTopLevel)
 
     case let .customCharacterClass(ccc):
       printAsPattern(ccc)
@@ -1430,9 +1412,6 @@ extension DSLTree.Node {
       for node in nodes {
         result += node.getNamedCaptures()
       }
-      
-    case .convertedRegexLiteral(let node, _):
-      result += node.getNamedCaptures()
       
     case .quantification(_, _, let node):
       result += node.getNamedCaptures()

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -20,21 +20,6 @@ extension AST {
 extension AST.Node {
   /// Converts an AST node to a `convertedRegexLiteral` node.
   var dslTreeNode: DSLTree.Node {
-//    func wrap(_ node: DSLTree.Node) -> DSLTree.Node {
-//      switch node {
-//      case .convertedRegexLiteral(let child, _):
-//        // FIXME: DSL can have one item concats
-////        assertionFailure("Double wrapping?")
-//        return child
-//      default:
-//        break
-//      }
-//      // TODO: Should we do this for the
-//      // single-concatenation child too, or should?
-//      // we wrap _that_?
-//      return node
-//    }
-
     // Convert the top-level node without wrapping
     func convert() throws -> DSLTree.Node {
       switch self {
@@ -105,9 +90,7 @@ extension AST.Node {
       }
     }
 
-    // FIXME: make total function again
     let converted = try! convert()
-//    return wrap(converted)
     return converted
   }
 }

--- a/Sources/_StringProcessing/Regex/ASTConversion.swift
+++ b/Sources/_StringProcessing/Regex/ASTConversion.swift
@@ -13,27 +13,27 @@ internal import _RegexParser
 
 extension AST {
   var dslTree: DSLTree {
-    return DSLTree(root.dslTreeNode)
+    return DSLTree(.limitCaptureNesting(root.dslTreeNode))
   }
 }
 
 extension AST.Node {
   /// Converts an AST node to a `convertedRegexLiteral` node.
   var dslTreeNode: DSLTree.Node {
-    func wrap(_ node: DSLTree.Node) -> DSLTree.Node {
-      switch node {
-      case .convertedRegexLiteral:
-        // FIXME: DSL can have one item concats
-//        assertionFailure("Double wrapping?")
-        return node
-      default:
-        break
-      }
-      // TODO: Should we do this for the
-      // single-concatenation child too, or should?
-      // we wrap _that_?
-      return .convertedRegexLiteral(node, .init(ast: self))
-    }
+//    func wrap(_ node: DSLTree.Node) -> DSLTree.Node {
+//      switch node {
+//      case .convertedRegexLiteral(let child, _):
+//        // FIXME: DSL can have one item concats
+////        assertionFailure("Double wrapping?")
+//        return child
+//      default:
+//        break
+//      }
+//      // TODO: Should we do this for the
+//      // single-concatenation child too, or should?
+//      // we wrap _that_?
+//      return node
+//    }
 
     // Convert the top-level node without wrapping
     func convert() throws -> DSLTree.Node {
@@ -107,7 +107,8 @@ extension AST.Node {
 
     // FIXME: make total function again
     let converted = try! convert()
-    return wrap(converted)
+//    return wrap(converted)
+    return converted
   }
 }
 

--- a/Sources/_StringProcessing/Regex/DSLList.swift
+++ b/Sources/_StringProcessing/Regex/DSLList.swift
@@ -25,41 +25,6 @@ struct DSLList {
   }
 }
 
-extension DSLList {
-  struct Children: Sequence {
-    var nodes: [DSLTree.Node]
-    var firstChildIndex: Int
-    
-    struct Iterator: IteratorProtocol {
-      var nodes: [DSLTree.Node]
-      var currentIndex: Int
-      var remainingCount: Int
-      
-      mutating func next() -> DSLTree.Node? {
-        guard remainingCount > 0 else { return nil }
-        guard currentIndex < nodes.count else {
-          // FIXME: assert?
-          print("ERROR: index out of bounds")
-          return nil
-        }
-        remainingCount -= 1
-        var nextIndex = currentIndex
-        var inc = nodes[currentIndex].directChildren + 1
-        while inc > 0 {
-          nextIndex += 1
-          inc += nodes[nextIndex].directChildren - 1
-        }
-
-        return nodes[currentIndex]
-      }
-    }
-    
-    func makeIterator() -> Iterator {
-      Iterator(nodes: nodes, currentIndex: firstChildIndex, remainingCount: nodes[firstChildIndex].directChildren)
-    }
-  }
-}
-
 extension DSLTree.Node {
   var directChildren: Int {
     switch self {

--- a/Sources/_StringProcessing/Regex/DSLList.swift
+++ b/Sources/_StringProcessing/Regex/DSLList.swift
@@ -67,8 +67,9 @@ extension DSLTree.Node {
     case .orderedChoice(let c), .concatenation(let c):
       return c.count
       
-    case .convertedRegexLiteral, .capture, .nonCapturingGroup,
-        .quantification, .ignoreCapturesInTypedOutput, .conditional:
+    case .capture, .nonCapturingGroup,
+        .quantification, .ignoreCapturesInTypedOutput,
+        .limitCaptureNesting, .conditional:
       return 1
       
     case .absentFunction:

--- a/Sources/_StringProcessing/Regex/DSLList.swift
+++ b/Sources/_StringProcessing/Regex/DSLList.swift
@@ -1,0 +1,113 @@
+//
+//  DSLList.swift
+//  swift-experimental-string-processing
+//
+//  Created by Nate Cook on 9/25/25.
+//
+
+struct DSLList {
+  var nodes: [DSLTree.Node]
+  
+  init(_ initial: DSLTree.Node) {
+    self.nodes = [initial]
+  }
+  
+  init(_ nodes: [DSLTree.Node]) {
+    self.nodes = nodes
+  }
+  
+  init(root: DSLTree.Node) {
+    self.nodes = Array(root)
+  }
+}
+
+extension DSLList {
+  struct Children: Sequence {
+    var nodes: [DSLTree.Node]
+    var firstChildIndex: Int
+    
+    struct Iterator: IteratorProtocol {
+      var nodes: [DSLTree.Node]
+      var currentIndex: Int
+      var remainingCount: Int
+      
+      mutating func next() -> DSLTree.Node? {
+        guard remainingCount > 0 else { return nil }
+        guard currentIndex < nodes.count else {
+          // FIXME: assert?
+          print("ERROR: index out of bounds")
+          return nil
+        }
+        remainingCount -= 1
+        var nextIndex = currentIndex
+        var inc = nodes[currentIndex].directChildren + 1
+        while inc > 0 {
+          nextIndex += 1
+          inc += nodes[nextIndex].directChildren - 1
+        }
+
+        return nodes[currentIndex]
+      }
+    }
+    
+    func makeIterator() -> Iterator {
+      Iterator(nodes: nodes, currentIndex: firstChildIndex, remainingCount: nodes[firstChildIndex].directChildren)
+    }
+  }
+}
+
+extension DSLTree.Node {
+  var directChildren: Int {
+    switch self {
+    case .trivia, .empty, .quotedLiteral,
+        .consumer, .matcher, .characterPredicate,
+        .customCharacterClass, .atom:
+      return 0
+      
+    case .orderedChoice(let c), .concatenation(let c):
+      return c.count
+      
+    case .convertedRegexLiteral, .capture, .nonCapturingGroup,
+        .quantification, .ignoreCapturesInTypedOutput, .conditional:
+      return 1
+      
+    case .absentFunction:
+      return 0
+    }
+  }
+}
+
+extension DSLTree.Node: Sequence {
+  struct Iterator: Sequence, IteratorProtocol {
+    typealias Element = DSLTree.Node
+    private var stack: [Frame]
+    private let getChildren: (Element) -> [Element]
+
+    private struct Frame {
+      let node: Element
+      let children: [Element]
+      var nextIndex: Int = 0
+    }
+
+    fileprivate init(
+      root: Element,
+      getChildren: @escaping (Element) -> [Element]
+    ) {
+      self.getChildren = getChildren
+      self.stack = [Frame(node: root, children: getChildren(root))]
+    }
+
+    mutating func next() -> Element? {
+      guard let top = stack.popLast() else { return nil }
+      // Push children in reverse so leftmost comes out first.
+      for child in top.children.reversed() {
+        stack.append(Frame(node: child, children: getChildren(child)))
+      }
+      return top.node
+    }
+  }
+  
+  func makeIterator() -> Iterator {
+    Iterator(root: self, getChildren: { $0.children })
+  }
+}

--- a/Tests/RegexTests/DSLListTests.swift
+++ b/Tests/RegexTests/DSLListTests.swift
@@ -1,21 +1,37 @@
+//===----------------------------------------------------------------------===//
 //
-//  DSLListTests.swift
-//  swift-experimental-string-processing
+// This source file is part of the Swift.org open source project
 //
-//  Created by Nate Cook on 9/25/25.
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
 //
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
 
 import Testing
 @testable import _StringProcessing
 
 @Suite
 struct DSLListTests {
-  @Test(arguments: [(#/abc/#, 4), (#/a(?:b+)c*/#, 7)])
-  func simple(regex: Regex<Substring>, nodeCount: Int) {
-    let dslList = DSLList(root: regex.root)
+  @available(macOS 9999, *)
+  @Test(arguments: [
+    (#/a/#, 2),             // literal, a
+    (#/abcd+/#, 5),         // literal, concat, abc, quant, d
+    (#/a(?:b+)c*/#, 8),     // literal, concat, a, noncap grp, quant, b, quant, c
+  ])
+  func convertedNodeCount(regex: Regex<Substring>, nodeCount: Int) {
+    let dslList = DSLList(tree: regex.program.tree)
     #expect(dslList.nodes.count == nodeCount)
-    for (i, node) in dslList.nodes.enumerated() {
-      print(i, node)
-    }
+  }
+  
+  @Test(arguments: [#/a|b/#, #/a+b?c/#, #/abc/#, #/a(?:b+)c*/#, #/;[\r\n]/#, #/(?=(?:[1-9]|(?:a|b)))/#])
+  func compilationComparison(regex: Regex<Substring>) throws {
+    let listCompiler = Compiler(tree: regex.program.tree)
+    let listProgram = try listCompiler.emitViaList()
+    let treeCompiler = Compiler(tree: regex.program.tree)
+    let treeProgram = try treeCompiler.emit()
+
+    #expect(treeProgram.instructions == listProgram.instructions)
   }
 }

--- a/Tests/RegexTests/DSLListTests.swift
+++ b/Tests/RegexTests/DSLListTests.swift
@@ -1,0 +1,21 @@
+//
+//  DSLListTests.swift
+//  swift-experimental-string-processing
+//
+//  Created by Nate Cook on 9/25/25.
+//
+
+import Testing
+@testable import _StringProcessing
+
+@Suite
+struct DSLListTests {
+  @Test(arguments: [(#/abc/#, 4), (#/a(?:b+)c*/#, 7)])
+  func simple(regex: Regex<Substring>, nodeCount: Int) {
+    let dslList = DSLList(root: regex.root)
+    #expect(dslList.nodes.count == nodeCount)
+    for (i, node) in dslList.nodes.enumerated() {
+      print(i, node)
+    }
+  }
+}

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -37,16 +37,34 @@ func _roundTripLiteral(
   return remadeRegex
 }
 
+func _validateListCompilation<T>(
+  _ regex: Regex<T>
+) throws -> Bool {
+  let treeCompiler = Compiler(tree: regex.program.tree)
+  let treeProgram = try treeCompiler.emit()
+  let listCompiler = Compiler(tree: regex.program.tree)
+  let listProgram = try listCompiler.emitViaList()
+  return treeProgram.instructions == listProgram.instructions
+}
+
 func _firstMatch(
   _ regexStr: String,
   input: String,
   validateOptimizations: Bool,
   semanticLevel: RegexSemanticLevel = .graphemeCluster,
-  syntax: SyntaxOptions = .traditional
+  syntax: SyntaxOptions = .traditional,
+  file: StaticString = #file,
+  line: UInt = #line
 ) throws -> (String, [String?])? {
   var regex = try Regex(regexStr, syntax: syntax).matchingSemantics(semanticLevel)
   let result = try regex.firstMatch(in: input)
-
+  
+  if try !_validateListCompilation(regex) {
+    XCTFail(
+      "List compilation failed for '\(regexStr)'",
+      file: file, line: line)
+  }
+  
   func validateSubstring(_ substringInput: Substring) throws {
     // Sometimes the characters we add to a substring merge with existing
     // string members. This messes up cross-validation, so skip the test.
@@ -105,14 +123,18 @@ func _firstMatch(
         For input '\(input)'
         Original: '\(regexStr)'
         _literalPattern: '\(roundTripRegex?._literalPattern ?? "<no pattern>")'
-        """)
+        """,
+        file: file,
+        line: line)
     case let (_, rtMatch?):
       XCTFail("""
         Incorrectly matched as '\(rtMatch)'
         For input '\(input)'
         Original: '\(regexStr)'
         _literalPattern: '\(roundTripRegex!._literalPattern!)'
-        """)
+        """,
+        file: file,
+        line: line)
     }
   }
 
@@ -184,7 +206,8 @@ func flatCaptureTest(
         input: test,
         validateOptimizations: validateOptimizations,
         semanticLevel: semanticLevel,
-        syntax: syntax
+        syntax: syntax,
+        file: file, line: line
       ) else {
         if expect == nil {
           continue
@@ -303,7 +326,8 @@ func firstMatchTest(
       input: input,
       validateOptimizations: validateOptimizations,
       semanticLevel: semanticLevel,
-      syntax: syntax)?.0
+      syntax: syntax,
+      file: file, line: line)?.0
 
     if xfail {
       XCTAssertNotEqual(found, match, file: file, line: line)

--- a/Tests/RegexTests/MatchTests.swift
+++ b/Tests/RegexTests/MatchTests.swift
@@ -41,7 +41,7 @@ func _validateListCompilation<T>(
   _ regex: Regex<T>
 ) throws -> Bool {
   let treeCompiler = Compiler(tree: regex.program.tree)
-  let treeProgram = try treeCompiler.emit()
+  let treeProgram = try treeCompiler.emitViaTree()
   let listCompiler = Compiler(tree: regex.program.tree)
   let listProgram = try listCompiler.emitViaList()
   return treeProgram.instructions == listProgram.instructions


### PR DESCRIPTION
The shared `DSLTree` type that is used to store the pre-compilation regex pattern is an indirect enumeration that has arbitrary nesting/recursion. This design makes it challenging both to reference different parts of the tree and to manipulate the tree during compilation for pre- and mid-compilation optimizations.

This change introduces a `DSLList` type that stores a pre-order traversal of the tree in an array, and an alternate bytecode generation path that consumes the `DSLList` instead of recursing over the `DSLTree`, with tests that the generated bytecode is identical between the two structures.

Still to do (note that compilation time will worsen until these are complete):
- modify the nodes to store only a child count instead of the children themselves
- generate the `DSLList` directly from parsing/instantiation
- eliminate use of the `DSLTree` representation